### PR TITLE
reduce test CI workflow run time

### DIFF
--- a/.github/workflows/run-dev-tests.yml
+++ b/.github/workflows/run-dev-tests.yml
@@ -42,8 +42,13 @@ jobs:
         uses: taiki-e/install-action@v2
         with:
           tool: cargo-nextest,cargo-llvm-cov,cargo-binstall,just
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+      - name: Install workflow deps
+        run: python3 -m pip install meson
       - run: just test
-        continue-on-error: true
+        # continue-on-error: true
       - name: save build as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/run-dev-tests.yml
+++ b/.github/workflows/run-dev-tests.yml
@@ -37,6 +37,19 @@ jobs:
           path: ~/.cargo
           key: ${{ runner.os }}-test-cargo-${{ hashFiles('Cargo.lock') }}
       - run: cargo fetch
+      - run: rustup component add llvm-tools-preview
+      - name: Install third-party binaries
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest,cargo-llvm-cov,cargo-binstall,just
+      - run: just test
+        continue-on-error: true
+      - name: save build as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          path: target/llvm-cov-target
+          name: cpp-linter-lib_tests-${{ runner.os }}-${{ github.run_id }}
+          retention-days: 1
 
   test:
     needs: [cache-deps]
@@ -112,6 +125,12 @@ jobs:
         with:
           path: ~/.cargo
           key: ${{ runner.os }}-test-cargo-${{ hashFiles('Cargo.lock') }}
+
+      - name: restore build from artifact
+        uses: actions/download-artifact@v4
+        with:
+          path: target/llvm-cov-target
+          name: cpp-linter-lib_tests-${{ runner.os }}-${{ github.run_id }}
 
       - name: Collect Coverage
         working-directory: cpp-linter-lib

--- a/.github/workflows/run-dev-tests.yml
+++ b/.github/workflows/run-dev-tests.yml
@@ -47,6 +47,12 @@ jobs:
           python-version: 3.x
       - name: Install workflow deps
         run: python3 -m pip install meson
+      - name: Install ninja (Linux)
+        if: runner.os == 'Linux'
+        run: sudo apt-get install ninja-build
+      - name: Install ninja (Windows)
+        if: runner.os == 'Windows'
+        run: choco install ninja
       - run: just test
         # continue-on-error: true
       - name: save build as artifact

--- a/.github/workflows/run-dev-tests.yml
+++ b/.github/workflows/run-dev-tests.yml
@@ -56,7 +56,7 @@ jobs:
       - run: just test
         # continue-on-error: true
       - name: Tar build assets
-        run: tar -cvf llvm-cov-target.tar target/llvm-cov-target
+        run: tar -cvf llvm-cov-assets.tar target/llvm-cov-target
       - name: save build as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/run-dev-tests.yml
+++ b/.github/workflows/run-dev-tests.yml
@@ -60,7 +60,7 @@ jobs:
       - name: save build as artifact
         uses: actions/upload-artifact@v4
         with:
-          path: llvm-cov-target.tar
+          path: llvm-cov-assets.tar
           name: cpp-linter-lib_tests-${{ runner.os }}-${{ github.run_id }}
           retention-days: 1
 

--- a/.github/workflows/run-dev-tests.yml
+++ b/.github/workflows/run-dev-tests.yml
@@ -55,10 +55,12 @@ jobs:
         run: choco install ninja
       - run: just test
         # continue-on-error: true
+      - name: Tar build assets
+        run: tar -cvf llvm-cov-target.tar target/llvm-cov-target
       - name: save build as artifact
         uses: actions/upload-artifact@v4
         with:
-          path: target/llvm-cov-target
+          path: llvm-cov-target.tar
           name: cpp-linter-lib_tests-${{ runner.os }}-${{ github.run_id }}
           retention-days: 1
 
@@ -140,8 +142,9 @@ jobs:
       - name: restore build from artifact
         uses: actions/download-artifact@v4
         with:
-          path: target/llvm-cov-target
           name: cpp-linter-lib_tests-${{ runner.os }}-${{ github.run_id }}
+      - name: Un-Tar build assets
+        run: tar -xvf llvm-cov-assets.tar
 
       - name: Collect Coverage
         working-directory: cpp-linter-lib


### PR DESCRIPTION
This involves saving a build per OS that can be as large as 2GB.