### PR TITLE
add ReadTheDocs config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,25 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    rust: latest
+  commands:
+    # install cargo-binstall
+    - >-
+      curl
+      -L --proto '=https' --tlsv1.2 -sSf
+      https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh
+      | bash
+    # install mdbook and mdbook-alerts
+    - cargo binstall -y mdbook mdbook-alerts
+    # build docs
+    - mdbook build docs
+    # move HTML output to required RTD output path
+    - mkdir -p ${READTHEDOCS_OUTPUT}
+    - mv docs/book/html/ "${READTHEDOCS_OUTPUT}"

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,10 +16,13 @@ build:
       -L --proto '=https' --tlsv1.2 -sSf
       https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh
       | bash
+    # add .cargo bin to PATH
     # install mdbook and mdbook-alerts
-    - cargo binstall -y mdbook mdbook-alerts
     # build docs
-    - mdbook build docs
+    - >-
+      PATH=/home/docs/.cargo/bin:$PATH &&
+      cargo binstall --install-path /home/docs/.cargo/bin -y mdbook mdbook-alerts &&
+      mdbook build docs
     # move HTML output to required RTD output path
     - mkdir -p ${READTHEDOCS_OUTPUT}
     - mv docs/book/html/ "${READTHEDOCS_OUTPUT}"


### PR DESCRIPTION
This is meant to allow docs preview in PR checks before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced configuration for building documentation using Read the Docs, enhancing the documentation process and accessibility.
- **Documentation**
	- Set up a streamlined build environment for documentation, including necessary tools for improved content generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->